### PR TITLE
feat: add support for arm64 image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ FROM ubuntu:22.04
 RUN apt-get update \
     && apt-get install -y wget procps file sudo libdw1
 
-# set the name of the package
-ENV DEBFILE=mimersqlsrv1108_11.0.8E-46583_amd64-openssl3.deb
-
 # fetch the package and install it
-RUN wget -nv -o {DEBFILE} https://download.mimer.com/pub/dist/linux_x86_64/${DEBFILE}
-RUN dpkg --install ${DEBFILE}
+RUN case "$(uname -m)" in \
+        aarch64) export MIMER_ARCH_SHORT="arm64" export MIMER_ARCH_LONG="linux_arm_64" ;; \
+        x86_64) export MIMER_ARCH_SHORT="amd64" export MIMER_ARCH_LONG="linux_x86_64" ;; \
+    esac; \
+    wget -nv -O mimersql.deb https://download.mimer.com/pub/dist/${MIMER_ARCH_LONG}/mimersqlsrv1108_11.0.8E-46583_${MIMER_ARCH_SHORT}-openssl3.deb && \
+    dpkg --install mimersql.deb
+
 STOPSIGNAL SIGINT
 
 # copy the start script and launch Mimer SQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN apt-get update \
 
 # fetch the package and install it
 RUN case "$(uname -m)" in \
-        aarch64) export MIMER_ARCH_SHORT="arm64" export MIMER_ARCH_LONG="linux_arm_64" ;; \
-        x86_64) export MIMER_ARCH_SHORT="amd64" export MIMER_ARCH_LONG="linux_x86_64" ;; \
+        aarch64) export MIMER_DEB="linux_arm_64/mimersqlsrv1108_11.0.8E-46583_arm64-openssl3.deb" ;; \
+        x86_64)  export MIMER_DEB="linux_x86_64/mimersqlsrv1108_11.0.8E-46583_amd64-openssl3.deb" ;; \
     esac; \
-    wget -nv -O mimersql.deb https://download.mimer.com/pub/dist/${MIMER_ARCH_LONG}/mimersqlsrv1108_11.0.8E-46583_${MIMER_ARCH_SHORT}-openssl3.deb && \
+    wget -nv -O mimersql.deb https://download.mimer.com/pub/dist/${MIMER_DEB} && \
     dpkg --install mimersql.deb
 
 STOPSIGNAL SIGINT


### PR DESCRIPTION
This PR adds support for running Mimer SQL on arm64. I extended the Dockerfile to differentiate between amd64 and armd64 when downloading the artifacts from the download server. I was able to build and run a Docker image locally on my arm64 based MacBook.